### PR TITLE
비동기 몽고를 통한 Message 도메인 구성 및 비동기 접근 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,6 @@ dependencies {
     // H2 in-memory database for testing and local development
     runtimeOnly 'com.h2database:h2'
 
-
     // querydsl
     implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"

--- a/src/main/java/com/codealpha/resoft_be/common/config/MongoConfig.java
+++ b/src/main/java/com/codealpha/resoft_be/common/config/MongoConfig.java
@@ -1,0 +1,26 @@
+package com.codealpha.resoft_be.common.config;
+import com.mongodb.ConnectionString;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.reactivestreams.client.MongoClient;
+import com.mongodb.reactivestreams.client.MongoClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.ReactiveMongoTemplate;
+
+@Configuration
+public class MongoConfig {
+    @Bean
+    public MongoClient mongoClient() {
+        ConnectionString connectionString = new ConnectionString("mongodb://localhost:27017/yourDatabaseName");
+        MongoClientSettings settings = MongoClientSettings.builder()
+                .applyConnectionString(connectionString)
+                .build();
+        return MongoClients.create(settings);
+    }
+
+    @Bean
+    public ReactiveMongoTemplate reactiveMongoTemplate() {
+        return new ReactiveMongoTemplate(mongoClient(), "yourDatabaseName");
+    }
+}
+

--- a/src/main/java/com/codealpha/resoft_be/domain/chatroom/entity/Chatroom.java
+++ b/src/main/java/com/codealpha/resoft_be/domain/chatroom/entity/Chatroom.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
-@Entity(name = "Chatrooms")
+@Entity(name = "chatrooms")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -30,8 +30,4 @@ public class Chatroom {
 
     @OneToOne
     UserChatroom userChatroom = null;
-
-    @OneToMany
-    @Builder.Default
-    List<Message> messages = new ArrayList<>();
 }

--- a/src/main/java/com/codealpha/resoft_be/domain/message/entity/Message.java
+++ b/src/main/java/com/codealpha/resoft_be/domain/message/entity/Message.java
@@ -1,23 +1,25 @@
 package com.codealpha.resoft_be.domain.message.entity;
 
 import com.codealpha.resoft_be.domain.chatroom.entity.Chatroom;
-import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Document;
 
-@Entity(name = "messages")
+@Document(collection = "messages")  // MongoDB에서 해당 클래스는 "messages" 컬렉션에 매핑됩니다.
+@Data  // @Getter, @Setter, @ToString, @EqualsAndHashCode를 한번에 처리
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
 public class Message {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    Long id;
-    @Column()
-    String message;
 
-    @ManyToOne
-    @Builder.Default
-    Chatroom chatroom = null;
+    @Id  // MongoDB의 고유 식별자 필드
+    private String id;  // MongoDB에서 기본적으로 String 타입의 _id를 사용하므로 변경
+
+    private String message;
+
+    private Long chatRoomId;
 }

--- a/src/main/java/com/codealpha/resoft_be/domain/message/repository/MessageRepository.java
+++ b/src/main/java/com/codealpha/resoft_be/domain/message/repository/MessageRepository.java
@@ -1,10 +1,10 @@
 package com.codealpha.resoft_be.domain.message.repository;
 
 import com.codealpha.resoft_be.domain.message.entity.Message;
-import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MessageRepository extends MongoRepository<Message, String> {
+public interface MessageRepository extends ReactiveMongoRepository<Message, String> {
     // 추가적인 쿼리 메서드를 정의할 수 있습니다.
 }

--- a/src/main/java/com/codealpha/resoft_be/domain/message/repository/MessageRepository.java
+++ b/src/main/java/com/codealpha/resoft_be/domain/message/repository/MessageRepository.java
@@ -1,7 +1,10 @@
 package com.codealpha.resoft_be.domain.message.repository;
 
 import com.codealpha.resoft_be.domain.message.entity.Message;
-import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
 
-public interface MessageRepository extends JpaRepository<Message, Long> {
+@Repository
+public interface MessageRepository extends MongoRepository<Message, String> {
+    // 추가적인 쿼리 메서드를 정의할 수 있습니다.
 }

--- a/src/main/java/com/codealpha/resoft_be/domain/user/entity/User.java
+++ b/src/main/java/com/codealpha/resoft_be/domain/user/entity/User.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
-@Entity
+@Entity(name="users")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/test/java/com/codealpha/resoft_be/ResoftBeApplicationTests.java
+++ b/src/test/java/com/codealpha/resoft_be/ResoftBeApplicationTests.java
@@ -2,10 +2,11 @@ package com.codealpha.resoft_be;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-class ResoftBeApplicationTests {
-
+@ActiveProfiles("local")
+public class ResoftBeApplicationTests {
     @Test
     void contextLoads() {
     }

--- a/src/test/java/com/codealpha/resoft_be/domain/message/MessageRespositoryTest.java
+++ b/src/test/java/com/codealpha/resoft_be/domain/message/MessageRespositoryTest.java
@@ -1,0 +1,168 @@
+package com.codealpha.resoft_be.domain.message;
+
+import com.codealpha.resoft_be.domain.message.entity.Message;
+import com.codealpha.resoft_be.domain.message.repository.MessageRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+@DataMongoTest
+@ExtendWith(SpringExtension.class)
+class MessageRepositoryTest {
+
+    @Autowired
+    private MessageRepository messageRepository;
+
+    @BeforeEach
+    void setUp() {
+        messageRepository.deleteAll().block();
+    }
+
+    Message createDummyMessage(String content, Long chatRoomId) {
+        return Message.builder()
+                .message(content)
+                .chatRoomId(chatRoomId)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("메시지 저장 테스트")
+    class 메시지저장테스트 {
+
+        @Test
+        @DisplayName("저장된 메시지를 반환해야 한다")
+        void 메시지저장_저장된메시지를반환해야한다() {
+            //given
+            Message message = createDummyMessage("안녕하세요", 1L);
+
+            //when
+            Mono<Message> savedMessage = messageRepository.save(message);
+
+            //then
+            StepVerifier.create(savedMessage)
+                    .expectNextMatches(msg -> msg.getMessage().equals("안녕하세요"))
+                    .verifyComplete();
+        }
+
+        @Test
+        @DisplayName("중복 채팅방 ID로 메시지를 저장하면 두 메시지를 모두 저장해야 한다")
+        void 중복채팅방ID로메시지저장_두메시지를모두저장해야한다() {
+            // given
+            Message message1 = createDummyMessage("안녕하세요", 1L);
+            Message message2 = createDummyMessage("안녕", 1L);
+
+            // when
+            Flux<Message> savedMessages = Flux.just(message1, message2)
+                    .flatMap(messageRepository::save);
+
+            // then
+            StepVerifier.create(savedMessages)
+                    .expectNextMatches(msg -> msg.getMessage().equals("안녕하세요"))
+                    .expectNextMatches(msg -> msg.getMessage().equals("안녕"))
+                    .verifyComplete();
+        }
+    }
+
+    @Nested
+    @DisplayName("메시지 조회 테스트")
+    class 메시지조회테스트 {
+
+        @Test
+        @DisplayName("메시지 ID로 조회하면 메시지를 반환해야 한다")
+        void 메시지ID로조회_메시지를반환해야한다() {
+            // given
+            Message message = createDummyMessage("안녕하세요", 1L);
+            Message savedMessage = messageRepository.save(message).block();
+
+            // when
+            Mono<Message> foundMessage = messageRepository.findById(savedMessage.getId());
+
+            // then
+            StepVerifier.create(foundMessage)
+                    .expectNextMatches(msg -> msg.getMessage().equals("안녕하세요"))
+                    .verifyComplete();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 메시지 ID로 조회하면 빈 결과를 반환해야 한다")
+        void 메시지ID로조회_존재하지않으면빈결과를반환해야한다() {
+            // when
+            Mono<Message> foundMessage = messageRepository.findById("nonexistentId");
+
+            // then
+            StepVerifier.create(foundMessage)
+                    .expectNextCount(0)
+                    .verifyComplete();
+        }
+    }
+
+    @Nested
+    @DisplayName("메시지 삭제 테스트")
+    class 메시지삭제테스트 {
+
+        @Test
+        @DisplayName("메시지를 삭제하면 메시지가 제거되어야 한다")
+        void 메시지삭제_메시지가제거되어야한다() {
+            // given
+            Message message = createDummyMessage("안녕하세요", 1L);
+            Message savedMessage = messageRepository.save(message).block();
+
+            // when
+            Mono<Void> deleteMessage = messageRepository.deleteById(savedMessage.getId());
+
+            // then
+            StepVerifier.create(deleteMessage)
+                    .verifyComplete();
+
+            // when
+            Mono<Message> foundMessage = messageRepository.findById(savedMessage.getId());
+
+            // then
+            StepVerifier.create(foundMessage)
+                    .expectNextCount(0)
+                    .verifyComplete();
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 메시지를 삭제하면 오류 없이 완료되어야 한다")
+        void 존재하지않는메시지삭제_오류없이완료되어야한다() {
+            // when
+            Mono<Void> deleteMessage = messageRepository.deleteById("nonexistentId");
+
+            // then
+            StepVerifier.create(deleteMessage)
+                    .verifyComplete();
+        }
+    }
+
+    @Nested
+    @DisplayName("메시지 카운트 테스트")
+    class 메시지카운트테스트 {
+
+        @Test
+        @DisplayName("메시지 카운트는 정확한 수를 반환해야 한다")
+        void 메시지카운트_정확한수를반환해야한다() {
+            // given
+            Message message1 = createDummyMessage("안녕하세요", 1L);
+            Message message2 = createDummyMessage("안녕", 2L);
+            messageRepository.save(message1).block();
+            messageRepository.save(message2).block();
+
+            // when
+            Mono<Long> count = messageRepository.count();
+
+            // then
+            StepVerifier.create(count)
+                    .expectNext(2L)
+                    .verifyComplete();
+        }
+    }
+}


### PR DESCRIPTION
## 연결 된 이슈
* #4 
## 🆕 기능 추가 / 🔧 버그 수정

-   **기능 추가**: Message 도메인이 Mongo DB 내에 반정형 데이터로써 저장 되도록 구성
